### PR TITLE
Added IMessageEventArgs interface

### DIFF
--- a/websocket-sharp/MessageEventArgs.cs
+++ b/websocket-sharp/MessageEventArgs.cs
@@ -44,8 +44,20 @@ namespace WebSocketSharp
   ///   the <see cref="Data"/> or <see cref="RawData"/> property.
   ///   </para>
   /// </remarks>
-  public class MessageEventArgs : EventArgs
+  ///
+
+  public interface IMessageEventArgs
   {
+    string Data { get; }
+    bool IsBinary { get; }
+    bool IsPing { get; }
+    bool IsText { get; }
+    byte[] RawData { get; }
+  }
+
+  public class MessageEventArgs : EventArgs, IMessageEventArgs
+	{
+
     #region Private Fields
 
     private string _data;


### PR DESCRIPTION
Added IMessageEventArgs interface and updated the MessageEventArgs class to use this interface (allows for a shared message event args interface between the JS socket and the WebsocketSharp socket)